### PR TITLE
chore: use knative.dev in module name

### DIFF
--- a/cmd/fce/main.go
+++ b/cmd/fce/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/event"
 
-	ce "github.com/knative-sandbox/func-go/cloudevents"
+	ce "knative.dev/func-go/cloudevents"
 )
 
 // Main illustrates how scaffolding works to wrap a user's function.

--- a/cmd/fhttp/main.go
+++ b/cmd/fhttp/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	fn "github.com/knative-sandbox/func-go/http"
+	fn "knative.dev/func-go/http"
 )
 
 // Main illustrates how scaffolding works to wrap a user's function.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knative-extensions/func-go
+module knative.dev/func-go
 
 go 1.19
 

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative-sandbox/func-go/http/mock"
+	"knative.dev/func-go/http/mock"
 )
 
 // TestStart ensures that the Start method of a function is invoked


### PR DESCRIPTION
# Changes

- :broom: Rename the module to `knative.dev/func-go`.