### PR TITLE
Support legacy static handler

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -86,6 +86,14 @@ func logImplements(f any) {
 	if _, ok := f.(LivenessReporter); ok {
 		log.Info().Msg("Function implements Alive")
 	}
+
+	// Warn if using the deprecated static handler:
+	if i, ok := f.(DefaultHandler); ok {
+		log.Info().Msg("Function implements Handle")
+		if _, ok = i.Handler.(handleFuncDeprecated); ok {
+			log.Warn().Msg("The Handle method signature used has been deprecated.  Please remove the context object argument.  Future versions will remove support for this signature.")
+		}
+	}
 }
 
 // Start

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -398,7 +398,7 @@ func TestAlive_Invoked(t *testing.T) {
 // TestHandle_WithContext ensures that the system allows compilation of
 // functions provided with the legacy Handler method signature.
 //
-// This compatibilty layer can be removed once func-go has been integrated
+// This compatibility layer can be removed once func-go has been integrated
 // into the Buildpack and S2I builders.
 func TestHandle_WithContext(t *testing.T) {
 	// This is the handler with the deprecated method signature:


### PR DESCRIPTION
Adds backwards compatibility for static handlers with context, as this is currently necessary while we port Pack and S2I builders to use this middleware.