### PR TITLE
fix backwards compatibility

### DIFF
--- a/http/instance.go
+++ b/http/instance.go
@@ -2,10 +2,7 @@ package http
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-
-	"github.com/rs/zerolog/log"
 )
 
 // Handler is a function instance which can handle a request.
@@ -49,19 +46,11 @@ type LivenessReporter interface {
 type DefaultHandler struct {
 	// TODO: Update type HandleFunc when backwards compatibility no
 	// longer needed:
-	Handler any
+	Handler handleFuncDeprecated
 }
 
 func (f DefaultHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	if i, ok := f.Handler.(HandleFunc); ok {
-		i(w, r)
-	} else if i, ok := f.Handler.(handleFuncDeprecated); ok {
-		i(r.Context(), w, r)
-	} else {
-		msg := "function does not implement Handle. Skipping invocation."
-		log.Debug().Msg(msg)
-		fmt.Fprintln(w, msg)
-	}
+	f.Handler(r.Context(), w, r)
 }
 
 type handleFuncDeprecated func(context.Context, http.ResponseWriter, *http.Request)

--- a/http/service.go
+++ b/http/service.go
@@ -86,14 +86,6 @@ func logImplements(f any) {
 	if _, ok := f.(LivenessReporter); ok {
 		log.Info().Msg("Function implements Alive")
 	}
-
-	// Warn if using the deprecated static handler:
-	if i, ok := f.(DefaultHandler); ok {
-		log.Info().Msg("Function implements Handle")
-		if _, ok = i.Handler.(handleFuncDeprecated); ok {
-			log.Warn().Msg("The Handle method signature used has been deprecated.  Please remove the context object argument.  Future versions will remove support for this signature.")
-		}
-	}
 }
 
 // Start


### PR DESCRIPTION
Fix backwards compatibility

Instanced functions use the new handler.  Static functions will still requre the context argument until such time as this library is integrated into both Pack and S2I